### PR TITLE
Updated README with full setup and operations documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,179 @@
 # Telegram Downloader Bot
 
-Telegram-бот для загрузки медиа из **Instagram (Reels/посты/карусели/сторис)**, **YouTube (включая Shorts)**, **TikTok**, **VK**, а также для поиска музыки по названию.
+Telegram-бот для скачивания и отправки медиа из Instagram, YouTube, TikTok, VK и Яндекс.Музыки.
 
-## Что важно знать про Instagram / 18+ / приватный контент
-Если ролик/пост/сторис:
-- приватный,
-- помечен как sensitive / 18+,
-- требует подтверждения возраста,
-- или Instagram отдаёт его только авторизованным пользователям,
+Бот умеет работать в личных сообщениях, группах и через Telegram inline mode: пользователь может написать `@bot_username <ссылка>` прямо в любом чате, выбрать результат, и медиа будет отправлено в этот же чат.
 
-то без **cookies авторизованного аккаунта** (сессии) `yt-dlp` часто не сможет скачать медиа.
+## Возможности
 
-Бот поддерживает **несколько cookies-файлов**: он пробует скачивание по очереди (первый, второй, третий…), пока не получится.
+- Instagram Reels, посты, карусели и сторис.
+- YouTube и YouTube Shorts.
+- TikTok и короткие ссылки `vt.tiktok.com`.
+- VK, `vk.cc` и `vkvideo.ru`.
+- Яндекс.Музыка по ссылке.
+- Поиск музыки по тексту в формате `Исполнитель - Название`.
+- Работа в личке, группах и супергруппах.
+- Inline-вызов из любого чата через `@bot_username ссылка`.
+- Кэширование скачанных файлов и Telegram `file_id`, чтобы не скачивать одну ссылку повторно.
+- Пользовательская загрузка Instagram cookies через команду `/pechenyuha`.
+- Ограничения по длительности, размеру, количеству файлов и параллельным скачиваниям.
+- Нормализация видео для лучшей совместимости с iPhone.
 
-## Ограничения/защита от лишних срабатываний
-Бот реагирует **только на ссылки поддерживаемых доменов** (строгие regex). На прочие ссылки не реагирует.
+## Быстрый Старт
 
-## Кэширование (анти-дублирование)
-Если одна и та же ссылка отправлена в разные чаты в течение TTL (по умолчанию **5 минут**), бот:
-- не скачивает заново,
-- использует кэш (и по возможности Telegram `file_id`).
+1. Создайте бота через `@BotFather` и получите токен.
+2. Склонируйте проект.
+3. Создайте `.env` в корне проекта.
+4. Запустите через Docker Compose.
 
-По истечении TTL кэш удаляется.
-
----
-
-## Стек
-- Python 3.10+
-- python-telegram-bot
-- yt-dlp
-- Docker
-
----
-
-## Конфигурация (.env)
-Создайте файл `.env` в корне проекта.
-
-Минимально:
-```env
-TOKEN=123456:ABCDEF
-ADMIN_ID=123456789
+```bash
+git clone https://github.com/SayonaraQ/downloadbot.git
+cd downloadbot
+cp .env.example .env
+mkdir -p data cookies
+docker compose up -d --build
 ```
 
-### Cookies (несколько файлов)
-Списки задаются через **запятую**, **точку с запятой** или **перенос строки**.
+Минимальный `.env`:
 
-Пример (для Instagram два аккаунта, и общий запасной файл):
 ```env
-IG_COOKIES_FILES=/app/cookies/ig_main.txt,/app/cookies/ig_backup.txt
+TOKEN=123456:ABCDEF
+ADMIN_ID=0
+```
+
+Проверка:
+
+```bash
+docker compose ps
+docker logs -f downloadbot_enhanced_v2
+```
+
+## Использование
+
+### Личное сообщение боту
+
+Отправьте ссылку боту напрямую:
+
+```text
+https://www.instagram.com/reel/...
+```
+
+Бот скачает медиа и отправит результат в этот же чат.
+
+### Группа или супергруппа
+
+Если бот добавлен в чат и имеет доступ к сообщениям, можно отправлять ссылку обычным сообщением:
+
+```text
+https://youtu.be/...
+```
+
+Также поддерживается упоминание:
+
+```text
+@DownloaderBot https://www.tiktok.com/...
+@DownloaderBot скачай https://www.instagram.com/reel/...
+```
+
+Бот удалит свое упоминание из текста, найдет поддерживаемую ссылку и отправит результат в этот же чат.
+
+### Inline Mode
+
+Inline mode нужен, чтобы отправлять медиа в чат, где бот не является участником, например в личный чат с другим человеком.
+
+Пример:
+
+```text
+@DownloaderBot https://www.instagram.com/reel/...
+```
+
+Telegram покажет inline-result. После выбора результата медиа будет отправлено прямо в текущий чат.
+
+Ограничение Telegram: бот не может сам отправить сообщение в чужой чат без выбора результата пользователем. Пользователь должен нажать на inline-result.
+
+## Настройка Inline Mode
+
+Включите inline mode у BotFather:
+
+```text
+/setinline
+```
+
+Выберите бота и задайте placeholder, например:
+
+```text
+Вставь ссылку на Instagram, TikTok, YouTube, VK или Яндекс.Музыку
+```
+
+### Кэш-чат для inline
+
+Telegram inline-results для медиа требуют готовый Telegram `file_id`. Чтобы получить `file_id`, бот должен один раз загрузить файл в чат, где он имеет право отправлять сообщения.
+
+Рекомендуемый вариант:
+
+1. Создайте приватный канал, например `downloadbot-cache`.
+2. Добавьте бота администратором в этот канал.
+3. Опубликуйте тестовое сообщение в канале.
+4. Скопируйте ссылку на сообщение. Для приватных каналов она выглядит так: `https://t.me/c/1234567890/1`.
+5. Получите chat id: добавьте `-100` перед числом после `/c/`. Для примера выше это `-1001234567890`.
+6. Укажите id в `.env`:
+
+```env
+INLINE_CACHE_CHAT_ID=-1001234567890
+```
+
+После этого бот будет загружать файлы в приватный кэш-канал, получать `file_id` и отдавать inline-result. Пользователь не будет получать временные файлы в личку.
+
+Если `INLINE_CACHE_CHAT_ID=0`, бот не будет отправлять файлы в личку для кэша. Для новых файлов inline-result покажет сообщение о необходимости настроить кэш-чат.
+
+## Конфигурация
+
+Все настройки задаются через `.env`.
+
+### Telegram
+
+```env
+TOKEN=123456:ABCDEF
+ADMIN_ID=0
+INLINE_CACHE_CHAT_ID=0
+```
+
+- `TOKEN` или `BOT_TOKEN` - токен Telegram-бота.
+- `ADMIN_ID` - Telegram user id администратора для команды `/users`. Если не нужен, используйте `0`.
+- `INLINE_CACHE_CHAT_ID` - id приватного канала/чата для подготовки inline media `file_id`.
+
+### Cookies
+
+```env
+IG_COOKIES_FILES=/app/cookies/instagram_main.txt,/app/cookies/instagram_backup.txt
+YT_COOKIES_FILES=/app/cookies/youtube.txt
+TT_COOKIES_FILES=/app/cookies/tiktok.txt
+VK_COOKIES_FILES=/app/cookies/vk.txt
 COOKIES_FILES=/app/cookies/fallback.txt
 ```
 
-Доступные переменные:
-- `IG_COOKIES_FILES` — cookies для Instagram
-- `YT_COOKIES_FILES` — cookies для YouTube
-- `TT_COOKIES_FILES` — cookies для TikTok
-- `VK_COOKIES_FILES` — cookies для VK
-- `COOKIES_FILES` (или `COOKIES_FILE`) — общий список (используется как fallback для всех)
+- `IG_COOKIES_FILES` - cookies для Instagram.
+- `YT_COOKIES_FILES` - cookies для YouTube.
+- `TT_COOKIES_FILES` - cookies для TikTok.
+- `VK_COOKIES_FILES` - cookies для VK.
+- `COOKIES_FILES` или `COOKIES_FILE` - общий fallback для всех сайтов.
 
-### Webhook (опционально вместо polling)
-По умолчанию бот работает через polling. Чтобы включить webhook, задайте:
-```env
-WEBHOOK_URL=https://your-domain.tld
-WEBHOOK_PORT=8080
-WEBHOOK_LISTEN=0.0.0.0
-WEBHOOK_PATH=your-secret-path
-WEBHOOK_SECRET_TOKEN=your-secret-token
-```
-
-Если `WEBHOOK_URL` не задан, бот автоматически запускается в polling-режиме.
+Списки можно разделять запятой, точкой с запятой или переносом строки.
 
 ### Кэш
+
 ```env
+CACHE_DIR=/app/data/cache
 CACHE_TTL_SECONDS=300
-CACHE_DIR=data/cache
 CACHE_CLEAN_INTERVAL_SECONDS=60
 ```
 
+- `CACHE_DIR` - каталог кэша.
+- `CACHE_TTL_SECONDS` - время жизни кэша в секундах.
+- `CACHE_CLEAN_INTERVAL_SECONDS` - интервал очистки кэша.
+
 ### Лимиты
+
 ```env
 MAX_CONCURRENT_DOWNLOADS=5
 MAX_DURATION_SEC=600
@@ -86,27 +182,177 @@ MAX_ITEMS_PER_LINK=10
 TRY_NO_COOKIES_FIRST=1
 ```
 
----
+- `MAX_CONCURRENT_DOWNLOADS` - максимум параллельных скачиваний.
+- `MAX_DURATION_SEC` - максимум длительности видео.
+- `MAX_SIZE_MB` - максимум размера файла для скачивания и отправки.
+- `MAX_ITEMS_PER_LINK` - максимум элементов из карусели/плейлиста.
+- `TRY_NO_COOKIES_FIRST` - сначала пробовать скачать без cookies, затем с cookies.
 
-## Запуск через Docker
+### iPhone-совместимость
 
-```bash
-docker build -t telegram-bot .
-
-# Папки data и cookies желательно примонтировать:
-mkdir -p data cookies
-
-docker run -d --name tg-bot \
-  --env-file .env \
-  -v $(pwd)/data:/app/data \
-  -v $(pwd)/cookies:/app/cookies \
-  --restart unless-stopped \
-  telegram-bot
+```env
+IOS_TRANSCODE_ENABLED=1
+IOS_TRANSCODE_MAX_PARALLEL=1
+IOS_TRANSCODE_PRESET=ultrafast
+IOS_TRANSCODE_CRF=28
+IOS_TRANSCODE_MAX_HEIGHT=720
+IOS_TRANSCODE_MAX_WIDTH=1280
+IOS_TRANSCODE_MAX_FPS=30
 ```
 
----
+Бот проверяет видео и при необходимости приводит его к более совместимому формату: H.264, AAC, `yuv420p`, четные размеры кадра.
 
-## Про cookies: кратко
-Cookies должны быть в формате **Netscape cookie file** (`cookies.txt`).
+### Webhook
 
-⚠️ Никогда не публикуйте cookies и не коммитьте их в git. Это фактически доступ к аккаунту.
+По умолчанию бот работает через polling. Для webhook задайте:
+
+```env
+WEBHOOK_URL=https://example.com
+WEBHOOK_LISTEN=0.0.0.0
+WEBHOOK_PORT=8080
+WEBHOOK_PATH=secret-path
+WEBHOOK_SECRET_TOKEN=secret-token
+```
+
+Если `WEBHOOK_URL` пустой, используется polling.
+
+### Яндекс.Музыка
+
+```env
+RU_PROXY=socks5://user:pass@host:port
+YA_COOKIES_FILE=/app/cookies/yandex.txt
+```
+
+Для некоторых ссылок Яндекс.Музыки могут понадобиться proxy и cookies.
+
+## Instagram Cookies
+
+Instagram часто не отдает Reels, сторис, приватные или sensitive-публикации без авторизованной сессии.
+
+Бот поддерживает два способа cookies:
+
+- статические cookies-файлы через `.env`, например `IG_COOKIES_FILES=/app/cookies/instagram.txt`;
+- пользовательская загрузка cookies в Telegram через `/pechenyuha`.
+
+### Загрузка cookies пользователем
+
+1. Откройте бота в личке.
+2. Отправьте команду:
+
+```text
+/pechenyuha
+```
+
+3. Отправьте файл `cookies.txt` как документ.
+4. Бот проверит формат и сохранит файл в `data/ig_user_cookies/user_<telegram_id>.txt`.
+
+При скачивании Instagram бот сначала использует cookies пользователя, который сделал запрос, затем остальные загруженные пользовательские cookies, затем cookies из `.env`.
+
+### Как выгрузить cookies.txt
+
+Для Chrome или Edge:
+
+1. Войдите в Instagram в браузере.
+2. Установите расширение `Get cookies.txt LOCALLY`.
+3. Откройте `instagram.com`.
+4. Нажмите на расширение и экспортируйте cookies.
+5. Сохраните файл как `cookies.txt`.
+
+Cookies должны быть в Netscape format: строки с tab-разделителями и доменом `instagram.com`.
+
+Никогда не публикуйте cookies и не коммитьте их в git. Cookies фактически дают доступ к аккаунту.
+
+## Команды Бота
+
+- `/start` - краткая инструкция.
+- `/pechenyuha` - начать загрузку Instagram cookies.
+- `/users` - количество сохраненных chat id, доступно только `ADMIN_ID`, если он задан.
+
+## Docker Compose
+
+Проект содержит `docker-compose.yml`:
+
+```bash
+mkdir -p data cookies
+docker compose up -d --build
+```
+
+Остановить:
+
+```bash
+docker compose down
+```
+
+Перезапустить:
+
+```bash
+docker compose restart
+```
+
+Логи:
+
+```bash
+docker logs -f downloadbot_enhanced_v2
+```
+
+## Эксплуатация На Сервере
+
+Типовой деплой:
+
+```bash
+cd /root/downloadbot
+git pull
+docker compose up -d --build
+docker compose ps
+docker logs --tail 100 downloadbot_enhanced_v2
+```
+
+Проверить переменные без вывода секретов:
+
+```bash
+grep -E '^(ADMIN_ID|INLINE_CACHE_CHAT_ID|CACHE_|MAX_|TRY_|IOS_|WEBHOOK_)' .env
+```
+
+Проверить сохраненные пользовательские Instagram cookies:
+
+```bash
+find data/ig_user_cookies -type f -name 'user_*.txt' -printf '%p %s bytes\n'
+```
+
+## Поведение И Ограничения
+
+- Бот реагирует только на поддерживаемые домены.
+- Обычные сообщения без ссылок игнорируются, кроме поиска музыки в формате `Исполнитель - Название`.
+- Inline-запросы должны содержать поддерживаемую ссылку.
+- Telegram inline API не позволяет боту самовольно отправлять сообщение в чужой чат: пользователь выбирает inline-result вручную.
+- Для inline media нужен заранее полученный Telegram `file_id`, поэтому рекомендуется `INLINE_CACHE_CHAT_ID`.
+- Instagram может требовать cookies даже для публичных Reels из-за rate limit, возраста, региона или авторизации.
+- Большие файлы могут не отправиться из-за лимитов Telegram и `MAX_SIZE_MB`.
+
+## Безопасность
+
+- Не коммитьте `.env`, cookies и пользовательские данные.
+- Храните cookies в `cookies/` или `data/ig_user_cookies/`, эти каталоги должны оставаться вне git.
+- Используйте отдельный Instagram-аккаунт для cookies, если бот публичный.
+- Не включайте подробные HTTP-логи с Telegram token. В коде `httpx` приглушен до `WARNING`, чтобы token не попадал в новые INFO-логи.
+
+## Отладка
+
+Проверить синтаксис:
+
+```bash
+python3 -m py_compile main.py
+```
+
+Посмотреть последние логи:
+
+```bash
+docker logs --tail 120 downloadbot_enhanced_v2
+```
+
+Частые проблемы:
+
+- `Requested content is not available, rate-limit reached or login required` - Instagram требует cookies.
+- `Нужен кэш-чат` в inline-result - настройте `INLINE_CACHE_CHAT_ID`.
+- Inline-result не появляется - проверьте `/setinline` в BotFather.
+- Видео пришло в кэш-канал, но не появилось в чате - проверьте, что бот админ кэш-канала и inline-result был выбран пользователем.

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import threading
 import time
+import uuid
 from contextlib import ExitStack
 from dataclasses import dataclass
 from pathlib import Path
@@ -21,6 +22,12 @@ from telegram import (
     InputFile,
     InputMediaPhoto,
     InputMediaVideo,
+    InputTextMessageContent,
+    InlineQueryResultArticle,
+    InlineQueryResultCachedAudio,
+    InlineQueryResultCachedDocument,
+    InlineQueryResultCachedPhoto,
+    InlineQueryResultCachedVideo,
     Update,
 )
 from telegram.ext import (
@@ -28,6 +35,7 @@ from telegram.ext import (
     ApplicationBuilder,
     CommandHandler,
     ContextTypes,
+    InlineQueryHandler,
     MessageHandler,
     filters,
 )
@@ -44,12 +52,14 @@ logging.basicConfig(
     level=logging.INFO,
 )
 logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 # -------------------------
 # Config
 # -------------------------
 TOKEN = os.getenv("TOKEN") or os.getenv("BOT_TOKEN")
 ADMIN_ID = int((os.getenv("ADMIN_ID") or "0").strip() or "0")
+INLINE_CACHE_CHAT_ID = int((os.getenv("INLINE_CACHE_CHAT_ID") or "0").strip() or "0")
 
 DATA_DIR = Path(os.getenv("DATA_DIR", "data"))
 USERS_FILE = DATA_DIR / "users.txt"
@@ -1393,6 +1403,232 @@ def _extract_yandex_url(text: str) -> str | None:
     return match.group(0).rstrip(".,!?)];") if match else None
 
 
+async def _get_or_download_media_entry(
+    url: str,
+    *,
+    requester_id: int | None,
+) -> dict[str, Any]:
+    site = _site_for_url(url)
+    key = _cache_key(url)
+
+    entry = _cache_index.get(key)
+    if entry and _cache_entry_is_usable(entry):
+        return entry
+
+    lock = _get_or_create_lock(key)
+    async with lock:
+        entry = _cache_index.get(key)
+        if entry and _cache_entry_is_usable(entry):
+            return entry
+
+        tmp_dir = Path("/tmp") / f"dl_{key[:12]}"
+        if tmp_dir.exists():
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            result = await asyncio.to_thread(
+                download_media_with_fallback,
+                url,
+                tmp_dir,
+                site,
+                requester_id,
+            )
+
+            files = [Path(p) for p in result["files"]]
+            files = files[:max(1, min(MAX_ITEMS_PER_LINK, 10_000))]
+
+            cache_dir = _cache_dir_for_key(key)
+            cache_dir.mkdir(parents=True, exist_ok=True)
+
+            items: list[dict[str, Any]] = []
+            for p in files:
+                kind = _classify_file(p)
+                target = cache_dir / p.name
+                if target.exists():
+                    target = cache_dir / f"{p.stem}_{int(_now())}{p.suffix}"
+                shutil.move(str(p), str(target))
+                items.append({
+                    "kind": kind,
+                    "local_filename": target.name,
+                    "tg_file_id": None,
+                })
+
+            entry = {
+                "key": key,
+                "url": url,
+                "site": site,
+                "title": result.get("title"),
+                "created_at": _now(),
+                "expires_at": _now() + float(CACHE_TTL_SECONDS),
+                "items": items,
+            }
+            _write_cache_entry(entry)
+            return entry
+        except Exception:
+            _purge_cache_entry(key)
+            raise
+        finally:
+            try:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+            except Exception:
+                pass
+
+
+async def _upload_inline_cache_item(
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    chat_id: int,
+    kind: str,
+    path: Path,
+) -> str:
+    with path.open("rb") as f:
+        if kind == "photo":
+            msg = await context.bot.send_photo(chat_id=chat_id, photo=f)
+            return msg.photo[-1].file_id
+        if kind == "video":
+            msg = await context.bot.send_video(chat_id=chat_id, video=f, supports_streaming=True)
+            return msg.video.file_id
+        if kind == "audio":
+            msg = await context.bot.send_audio(chat_id=chat_id, audio=f, title=path.stem)
+            return msg.audio.file_id
+        msg = await context.bot.send_document(chat_id=chat_id, document=f)
+        return msg.document.file_id
+
+
+async def _ensure_inline_file_ids(
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    entry: dict[str, Any],
+    upload_chat_id: int,
+) -> None:
+    cache_dir = _cache_dir_for_key(str(entry["key"]))
+    changed = False
+
+    for item in entry.get("items") or []:
+        if item.get("tg_file_id"):
+            continue
+        local_filename = item.get("local_filename")
+        if not local_filename:
+            continue
+        path = cache_dir / local_filename
+        if not path.exists() or not path.is_file():
+            continue
+        item["tg_file_id"] = await _upload_inline_cache_item(
+            context,
+            chat_id=upload_chat_id,
+            kind=item.get("kind") or "document",
+            path=path,
+        )
+        changed = True
+
+    if changed:
+        _write_cache_entry(entry)
+
+
+def _inline_article(title: str, message: str) -> InlineQueryResultArticle:
+    return InlineQueryResultArticle(
+        id=str(uuid.uuid4()),
+        title=title,
+        input_message_content=InputTextMessageContent(message),
+    )
+
+
+def _entry_has_inline_file_ids(entry: dict[str, Any]) -> bool:
+    items = entry.get("items") or []
+    return bool(items) and all(item.get("tg_file_id") for item in items)
+
+
+async def handle_inline_query(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    inline_query = update.inline_query
+    if inline_query is None:
+        return
+
+    text = inline_query.query.strip()
+    if not text:
+        await inline_query.answer(
+            [_inline_article("Вставь ссылку", "Напиши: @bot ссылка на Instagram, TikTok, YouTube, VK или Яндекс.Музыку")],
+            cache_time=1,
+            is_personal=True,
+        )
+        return
+
+    upload_chat_id = INLINE_CACHE_CHAT_ID
+    requester_id = inline_query.from_user.id if inline_query.from_user else None
+    yandex_url = _extract_yandex_url(text)
+    video_url = _extract_supported_video_url(text)
+
+    try:
+        if yandex_url:
+            audio_filename = None
+            try:
+                audio_filename = await asyncio.to_thread(download_audio_by_url, yandex_url)
+                path = Path(audio_filename)
+                file_id = await _upload_inline_cache_item(
+                    context,
+                    chat_id=upload_chat_id,
+                    kind="audio",
+                    path=path,
+                )
+                await inline_query.answer(
+                    [InlineQueryResultCachedAudio(id=str(uuid.uuid4()), audio_file_id=file_id)],
+                    cache_time=0,
+                    is_personal=True,
+                )
+            finally:
+                if audio_filename and os.path.exists(audio_filename):
+                    os.remove(audio_filename)
+            return
+
+        if not video_url:
+            await inline_query.answer(
+                [_inline_article("Ссылка не найдена", "Укажи ссылку на Instagram, TikTok, YouTube, VK или Яндекс.Музыку после имени бота.")],
+                cache_time=1,
+                is_personal=True,
+            )
+            return
+
+        entry = await _get_or_download_media_entry(video_url, requester_id=requester_id)
+        if not upload_chat_id and not _entry_has_inline_file_ids(entry):
+            await inline_query.answer(
+                [_inline_article(
+                    "Нужен кэш-чат",
+                    "Для inline-отправки без сообщений в личку настрой INLINE_CACHE_CHAT_ID: создай приватный канал, добавь бота админом и укажи id канала в .env.",
+                )],
+                cache_time=1,
+                is_personal=True,
+            )
+            return
+
+        await _ensure_inline_file_ids(context, entry=entry, upload_chat_id=upload_chat_id)
+
+        results: list[Any] = []
+        for i, item in enumerate(entry.get("items") or [], start=1):
+            file_id = item.get("tg_file_id")
+            if not file_id:
+                continue
+            kind = item.get("kind")
+            result_id = f"{str(entry['key'])[:48]}_{i}"
+            if kind == "photo":
+                results.append(InlineQueryResultCachedPhoto(id=result_id, photo_file_id=file_id))
+            elif kind == "video":
+                results.append(InlineQueryResultCachedVideo(id=result_id, video_file_id=file_id, title="Видео"))
+            else:
+                results.append(InlineQueryResultCachedDocument(id=result_id, document_file_id=file_id, title="Файл"))
+
+        if not results:
+            results = [_inline_article("Не удалось подготовить медиа", "Попробуй отправить ссылку боту напрямую.")]
+
+        await inline_query.answer(results[:50], cache_time=0, is_personal=True)
+    except Exception as e:
+        logger.error("Ошибка inline-запроса: %s", e)
+        await inline_query.answer(
+            [_inline_article("Не удалось загрузить", "Попробуй отправить ссылку боту напрямую или повторить позже.")],
+            cache_time=1,
+            is_personal=True,
+        )
+
+
 async def _get_bot_username(context: ContextTypes.DEFAULT_TYPE) -> str | None:
     username = context.bot_data.get("bot_username")
     if isinstance(username, str):
@@ -1468,89 +1704,16 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         # 2) Supported video/media URLs only
         if _looks_like_supported_video_url(text):
             url = text
-            site = _site_for_url(url)
-            key = _cache_key(url)
-
-            # If cached - send immediately
-            entry = _cache_index.get(key)
-            if entry and _cache_entry_is_usable(entry):
-                try:
-                    await send_cache_entry(update, context, entry)
-                    return
-                except Exception as e:
-                    logger.warning(f"Кэш найден, но отправка не удалась (будет перезакачка): {e}")
-                    _purge_cache_entry(key)
-
-            lock = _get_or_create_lock(key)
-            async with lock:
-                # re-check after lock
-                entry = _cache_index.get(key)
-                if entry and _cache_entry_is_usable(entry):
-                    await send_cache_entry(update, context, entry)
-                    return
-
-                tmp_dir = Path("/tmp") / f"dl_{key[:12]}"
-                if tmp_dir.exists():
-                    shutil.rmtree(tmp_dir, ignore_errors=True)
-                tmp_dir.mkdir(parents=True, exist_ok=True)
-
-                try:
-                    result = await asyncio.to_thread(
-                        download_media_with_fallback,
-                        url,
-                        tmp_dir,
-                        site,
-                        requester_id,
-                    )
-
-                    files = [Path(p) for p in result["files"]]
-                    # Apply MAX_ITEMS_PER_LINK also post-download (safety)
-                    files = files[:max(1, min(MAX_ITEMS_PER_LINK, 10_000))]
-
-                    cache_dir = _cache_dir_for_key(key)
-                    cache_dir.mkdir(parents=True, exist_ok=True)
-
-                    items: list[dict[str, Any]] = []
-                    for p in files:
-                        kind = _classify_file(p)
-                        # Put into cache folder
-                        target = cache_dir / p.name
-                        if target.exists():
-                            # avoid collisions
-                            target = cache_dir / f"{p.stem}_{int(_now())}{p.suffix}"
-                        shutil.move(str(p), str(target))
-                        items.append({
-                            "kind": kind,
-                            "local_filename": target.name,
-                            "tg_file_id": None,
-                        })
-
-                    entry = {
-                        "key": key,
-                        "url": url,
-                        "site": site,
-                        "title": result.get("title"),
-                        "created_at": _now(),
-                        "expires_at": _now() + float(CACHE_TTL_SECONDS),
-                        "items": items,
-                    }
-                    _write_cache_entry(entry)
-
-                    await send_cache_entry(update, context, entry)
-
-                except ValueError as e:
-                    await update.message.reply_text(str(e))
-                except Exception as e:
-                    logger.error(f"Ошибка: {e}")
-                    await update.message.reply_text(
-                        "Не удалось загрузить. Возможно пора обновить cookies"
-                    )
-                    _purge_cache_entry(key)
-                finally:
-                    try:
-                        shutil.rmtree(tmp_dir, ignore_errors=True)
-                    except Exception:
-                        pass
+            try:
+                entry = await _get_or_download_media_entry(url, requester_id=requester_id)
+                await send_cache_entry(update, context, entry)
+            except ValueError as e:
+                await update.message.reply_text(str(e))
+            except Exception as e:
+                logger.error(f"Ошибка: {e}")
+                await update.message.reply_text(
+                    "Не удалось загрузить. Возможно пора обновить cookies"
+                )
             return
 
         # 3) Music by query
@@ -1584,6 +1747,7 @@ def build_application() -> Application:
     app.add_handler(CommandHandler("pechenyuha", pechenyuha_command))
     app.add_handler(CommandHandler("users", get_users_count))
     app.add_handler(CommandHandler("start", start_command))
+    app.add_handler(InlineQueryHandler(handle_inline_query))
     app.add_handler(MessageHandler(filters.Document.ALL, handle_cookie_document))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
 


### PR DESCRIPTION
Updated README with full setup and operations documentation.

Added:
- regular chat and inline mode usage examples;
- BotFather `/setinline` setup instructions;
- `INLINE_CACHE_CHAT_ID` cache channel explanation;
- Instagram cookies upload flow via `/pechenyuha`;
- full `.env` configuration reference;
- Docker Compose deployment and server operations commands;
- troubleshooting notes for Instagram cookies, inline mode, and cache chat.